### PR TITLE
UI実装 ダッシュボード画面を実装した

### DIFF
--- a/app/(auth)/dashboard/TaskList.tsx
+++ b/app/(auth)/dashboard/TaskList.tsx
@@ -34,7 +34,7 @@ export const TaskList = ({ tasks }: Props) => {
                 {task.priorityTypeName}
               </PriorityTypeBadge>
             )}
-            <Button variant="ghost" className="hover:cursor-pointer">
+            <Button variant="ghost" className="cursor-pointer">
               <BsThreeDots />
             </Button>
           </div>

--- a/app/(auth)/dashboard/TaskList.tsx
+++ b/app/(auth)/dashboard/TaskList.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { BsThreeDots } from "react-icons/bs";
+import { PriorityTypeBadge } from "@/components/task/PriorityTypeBadge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
+import type { Task } from "@/types/taskTypes";
+
+interface Props {
+  tasks: Task[];
+}
+
+/**
+ * タスクリスト表示コンポーネント
+ * @param tasks タスク一覧
+ */
+export const TaskList = ({ tasks }: Props) => {
+  return (
+    <FieldGroup className="flex flex-col gap-0">
+      {tasks.map((task, index) => (
+        <Field
+          key={task.id}
+          orientation="horizontal"
+          className={`border${index === tasks.length - 1 ? "-y" : "-t"} p-4 justify-between`}
+        >
+          <div className="flex items-center gap-4">
+            <Checkbox id={task.id.toString()} name={task.id.toString()} />
+            <FieldLabel htmlFor={task.id.toString()}>{task.name}</FieldLabel>
+          </div>
+          <div className="flex items-center gap-4">
+            {task.priorityType && task.priorityTypeName && (
+              <PriorityTypeBadge priorityType={task.priorityType}>
+                {task.priorityTypeName}
+              </PriorityTypeBadge>
+            )}
+            <Button variant="ghost" className="hover:cursor-pointer">
+              <BsThreeDots />
+            </Button>
+          </div>
+        </Field>
+      ))}
+    </FieldGroup>
+  );
+};

--- a/app/(auth)/dashboard/TaskListContainer.tsx
+++ b/app/(auth)/dashboard/TaskListContainer.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import { TbPlus } from "react-icons/tb";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+import type { Task } from "@/types/taskTypes";
+import { TaskList } from "./TaskList";
+
+interface Props {
+  tasks: Task[];
+}
+
+export const TaskListContainer = ({ tasks }: Props) => {
+  const [selectedTab, setSelectedTab] = useState("all");
+
+  const getTabClassName = () => {
+    return cn(
+      "cursor-pointer",
+      "rounded-t-sm",
+      "rounded-b-none",
+      "h-fit",
+      "py-1",
+      "px-4",
+      "group-data-[variant=line]/tabs-list:data-active:bg-primary/10 after:bg-primary",
+      "dark:group-data-[variant=line]/tabs-list:data-active:bg-primary/30 after:bg-primary",
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <Tabs
+          defaultValue={selectedTab}
+          onValueChange={(v) => setSelectedTab(v)}
+          className="w-full"
+        >
+          <TabsList variant="line">
+            <TabsTrigger value="all" className={getTabClassName()}>
+              All Tasks
+            </TabsTrigger>
+            <TabsTrigger value="inProgress" className={getTabClassName()}>
+              In Progress
+            </TabsTrigger>
+            <TabsTrigger value="completed" className={getTabClassName()}>
+              Completed
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+        <Button className="px-4 py-2 h-fit cursor-pointer">
+          <TbPlus />
+          Add
+        </Button>
+      </div>
+      <TaskList tasks={tasks} />
+    </div>
+  );
+};

--- a/app/(auth)/dashboard/page.tsx
+++ b/app/(auth)/dashboard/page.tsx
@@ -14,7 +14,7 @@ export default function Page() {
       id: 2,
       name: "掃除する",
       priorityType: "low",
-      priorityTypeName: "LOW",
+      priorityTypeName: "低",
       isCompleted: false,
       createdAt: new Date("2026/04/27"),
       updatedAt: new Date("2026/04/27"),

--- a/app/(auth)/dashboard/page.tsx
+++ b/app/(auth)/dashboard/page.tsx
@@ -1,0 +1,24 @@
+import type { Task } from "@/types/taskTypes";
+import { TaskListContainer } from "./TaskListContainer";
+
+export default function Page() {
+  const tasks: Task[] = [
+    {
+      id: 1,
+      name: "早起きする",
+      isCompleted: false,
+      createdAt: new Date("2026/04/27"),
+      updatedAt: new Date("2026/04/27"),
+    },
+    {
+      id: 2,
+      name: "掃除する",
+      priorityType: "low",
+      priorityTypeName: "LOW",
+      isCompleted: false,
+      createdAt: new Date("2026/04/27"),
+      updatedAt: new Date("2026/04/27"),
+    },
+  ];
+  return <TaskListContainer tasks={tasks} />;
+}

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -8,7 +8,7 @@ export default function AuthLayout({
   return (
     <div>
       <Header />
-      {children}
+      <div className="p-8">{children}</div>
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -37,6 +37,9 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  --priority-low: oklch(0.66 0.11 157);
+  --priority-medium: oklch(0.66 0.15 53);
+  --priority-high: oklch(0.55 0.17 13);
 }
 
 @theme inline {
@@ -82,6 +85,9 @@
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
+  --color-priority-low: var(--priority-low);
+  --color-priority-medium: var(--priority-medium);
+  --color-priority-high: var(--priority-high);
 }
 
 .dark {

--- a/components/task/PriorityTypeBadge.tsx
+++ b/components/task/PriorityTypeBadge.tsx
@@ -27,7 +27,7 @@ export const PriorityTypeBadge = ({ priorityType, children }: Props) => {
 
   return (
     <Badge
-      className={`${getBgColor()} h-fit py-1 px-2 rounded-sm text-white font-bold`}
+      className={`${getBgColor()} h-fit py-1 px-2 w-20 rounded-sm text-white font-bold`}
     >
       {children}
     </Badge>

--- a/components/task/PriorityTypeBadge.tsx
+++ b/components/task/PriorityTypeBadge.tsx
@@ -1,0 +1,35 @@
+import { Badge } from "@/components/ui/badge";
+import type { Task } from "@/types/taskTypes";
+
+interface Props {
+  priorityType: Task["priorityType"];
+  children: React.ReactNode;
+}
+
+/**
+ * タスクの優先度バッジ
+ * @param priorityType タスクの優先度
+ * @@param children
+ */
+export const PriorityTypeBadge = ({ priorityType, children }: Props) => {
+  const getBgColor = () => {
+    switch (priorityType) {
+      case "high":
+        return "bg-priority-high";
+      case "medium":
+        return "bg-priority-medium";
+      case "low":
+        return "bg-priority-low";
+      default:
+        break;
+    }
+  };
+
+  return (
+    <Badge
+      className={`${getBgColor()} h-fit py-1 px-2 rounded-sm text-white font-bold`}
+    >
+      {children}
+    </Badge>
+  );
+};

--- a/components/task/PriorityTypeBadge.tsx
+++ b/components/task/PriorityTypeBadge.tsx
@@ -29,7 +29,7 @@ export const PriorityTypeBadge = ({ priorityType, children }: Props) => {
     <Badge
       className={`${getBgColor()} h-fit py-1 px-2 w-20 rounded-sm text-white font-bold`}
     >
-      {children}
+      優先度：{children}
     </Badge>
   );
 };

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,49 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { CheckIcon } from "lucide-react"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
+      >
+        <CheckIcon
+        />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { cva, type VariantProps } from "class-variance-authority";
+import { Tabs as TabsPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-horizontal:flex-col",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> &
+  VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 text-sm outline-none", className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsContent, TabsList, TabsTrigger, tabsListVariants };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-icons": "^5.6.0",
     "shadcn": "^4.3.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      react-icons:
+        specifier: ^5.6.0
+        version: 5.6.0(react@19.2.4)
       shadcn:
         specifier: ^4.3.0
         version: 4.3.0(@types/node@20.19.39)(typescript@5.9.3)
@@ -3203,6 +3206,11 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-icons@5.6.0:
+    resolution: {integrity: sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==}
+    peerDependencies:
+      react: '*'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -7087,6 +7095,10 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-icons@5.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   react-is@16.13.1: {}
 

--- a/types/authTypes.ts
+++ b/types/authTypes.ts
@@ -1,0 +1,11 @@
+/** ログインユーザー */
+export interface LoginUser {
+  /** ID(一意) */
+  id: number;
+  /** ユーザーID */
+  userId: string;
+  /** ユーザー名 */
+  name: string;
+  /** メールアドレス */
+  email: string;
+}

--- a/types/taskTypes.ts
+++ b/types/taskTypes.ts
@@ -1,0 +1,12 @@
+/** タスク */
+export interface Task {
+  /** タスクID (連番) */
+  id: number;
+  /**タスク名 */
+  name: string;
+  priorityType?: "low" | "medium" | "high";
+  dueDate?: Date;
+  isCompleted: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/types/taskTypes.ts
+++ b/types/taskTypes.ts
@@ -7,7 +7,7 @@ export interface Task {
   /** 優先度タイプ */
   priorityType?: "low" | "medium" | "high";
   /** 優先度名 */
-  priorityTypeName?: "LOW" | "MEDIUM" | "HIGH";
+  priorityTypeName?: "低" | "中" | "高";
   /** 期限 */
   dueDate?: Date;
   /** 完了フラグ */

--- a/types/taskTypes.ts
+++ b/types/taskTypes.ts
@@ -4,9 +4,16 @@ export interface Task {
   id: number;
   /**タスク名 */
   name: string;
+  /** 優先度タイプ */
   priorityType?: "low" | "medium" | "high";
+  /** 優先度名 */
+  priorityTypeName?: "LOW" | "MEDIUM" | "HIGH";
+  /** 期限 */
   dueDate?: Date;
+  /** 完了フラグ */
   isCompleted: boolean;
+  /** 作成日 */
   createdAt: Date;
+  /** 編集日 */
   updatedAt: Date;
 }


### PR DESCRIPTION
## 変更内容
ダッシュボード画面を実装し、タスクリストが表示されるようにした。

## 完了条件
- ヘッダーが表示される(認証後に表示されるすべての画面に表示)
- タスクリストが表示される
  - タスク名、タスクの優先度が表示される(優先度はバッジで表示)
- タスクフィルター用のタブが表示される (All Tasks(全て), In Progress(進行中), Completed(完了済み))
- タスク追加ボタンが表示される

## 補足事項
### ダッシュボード画面
**ライトモード**
<img width="1483" height="835" alt="スクリーンショット 2026-05-03 12 03 49" src="https://github.com/user-attachments/assets/5c93f7c0-0a96-49ec-b3b6-b63fe75493f1" />

**ダークモード**
<img width="1463" height="709" alt="スクリーンショット 2026-05-03 12 00 47" src="https://github.com/user-attachments/assets/de2706d5-e3ca-4654-af7c-aa747437fb68" />


