### PR TITLE
UI実装 タスク削除モーダルのUIを実装した

### DIFF
--- a/app/(auth)/dashboard/TaskList.tsx
+++ b/app/(auth)/dashboard/TaskList.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Fragment, useState } from "react";
 import { BsThreeDots } from "react-icons/bs";
+import { TbTrash } from "react-icons/tb";
+import { DeleteTaskModal } from "@/components/task/modal/DeleteTaskModal";
 import { PriorityTypeBadge } from "@/components/task/PriorityTypeBadge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -18,29 +22,56 @@ interface Props {
  * @param tasks タスク一覧
  */
 export const TaskList = ({ tasks }: Props) => {
+  const [isDeleteTaskModalOpen, setIsDeleteTaskModalOpen] = useState(false);
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+  const router = useRouter();
+
+  const handleDeleteTaskModalOpen = (task: Task) => {
+    setIsDeleteTaskModalOpen(true);
+    setSelectedTask(task);
+  };
+
   return (
     <FieldGroup className="flex flex-col gap-0">
       {tasks.map((task, index) => (
-        <Field
-          key={task.id}
-          orientation="horizontal"
-          className={`border${index === tasks.length - 1 ? "-y" : "-t"} p-4 justify-between`}
-        >
-          <div className="flex items-center gap-4">
-            <Checkbox id={task.id.toString()} name={task.id.toString()} />
-            <FieldLabel htmlFor={task.id.toString()}>{task.name}</FieldLabel>
-          </div>
-          <div className="flex items-center gap-4">
-            {task.priorityType && (
-              <PriorityTypeBadge priorityType={task.priorityType} />
-            )}
-            <Button variant="ghost" className="cursor-pointer">
-              <Link href={Paths.TASK_DETAIL.replace(":id", task.id.toString())}>
-                <BsThreeDots />
-              </Link>
-            </Button>
-          </div>
-        </Field>
+        <Fragment key={task.id}>
+          <Field
+            orientation="horizontal"
+            className={`border${index === tasks.length - 1 ? "-y" : "-t"} p-4 justify-between`}
+          >
+            <div className="flex items-center gap-4">
+              <Checkbox id={task.id.toString()} name={task.id.toString()} />
+              <FieldLabel htmlFor={task.id.toString()}>{task.name}</FieldLabel>
+            </div>
+            <div className="flex items-center gap-4">
+              {task.priorityType && (
+                <PriorityTypeBadge priorityType={task.priorityType} />
+              )}
+              <Button
+                onClick={() => handleDeleteTaskModalOpen(task)}
+                variant="ghost"
+              >
+                <TbTrash />
+              </Button>
+              <Button variant="ghost" className="cursor-pointer">
+                <Link
+                  href={Paths.TASK_DETAIL.replace(":id", task.id.toString())}
+                >
+                  <BsThreeDots />
+                </Link>
+              </Button>
+            </div>
+          </Field>
+          {!!selectedTask && (
+            <DeleteTaskModal
+              key={selectedTask.id}
+              opened={isDeleteTaskModalOpen}
+              task={selectedTask}
+              onOpenChange={setIsDeleteTaskModalOpen}
+              onDelete={() => router.refresh()}
+            />
+          )}
+        </Fragment>
       ))}
     </FieldGroup>
   );

--- a/app/(auth)/dashboard/[id]/TaskDetail.tsx
+++ b/app/(auth)/dashboard/[id]/TaskDetail.tsx
@@ -1,5 +1,15 @@
+"use client";
+
 import dayjs from "dayjs";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { BsPencil } from "react-icons/bs";
+import { TbTrash } from "react-icons/tb";
 import Markdown from "react-markdown";
+import { DeleteTaskModal } from "@/components/task/modal/DeleteTaskModal";
+import { Button } from "@/components/ui/button";
+import { Paths } from "@/consts/consts";
 import { PRIORITY_LABEL, STATUS_LABEL } from "@/consts/task";
 import { markdownComponents } from "@/lib/markdownComponents";
 import { markdownRemarkPlugins } from "@/lib/markdownPlugins";
@@ -10,56 +20,88 @@ interface Props {
 }
 
 export const TaskDetail = ({ task }: Props) => {
+  const [isDeleteTaskModalOpen, setIsDeleteTaskModalOpen] = useState(false);
+  const router = useRouter();
+
   return (
-    <div className="flex gap-4 w-full">
-      <div className="border rounded-lg p-4 flex flex-col gap-4 min-h-50 w-[70%]">
-        <div className="flex flex-col gap-2">
-          <div className="min-w-[150px] font-bold">説明</div>
-          <Markdown
-            components={markdownComponents}
-            remarkPlugins={markdownRemarkPlugins}
+    <>
+      <div className="flex justify-between">
+        <h1 className="text-2xl font-bold">{task.name}</h1>
+        <div className="flex gap-4 items-center">
+          <Button
+            onClick={() => setIsDeleteTaskModalOpen(true)}
+            variant="destructive"
+            className="px-4 py-2 h-fit"
           >
-            {task.description}
-          </Markdown>
+            <TbTrash />
+            削除
+          </Button>
+          <Button asChild className="px-4 py-2 h-fit">
+            <Link href={Paths.TASK_EDIT.replace(":id", task.id.toString())}>
+              <BsPencil />
+              編集
+            </Link>
+          </Button>
         </div>
       </div>
-      <div className="border rounded-lg p-4 flex flex-col gap-2 w-[30%]">
-        <h3 className="text-md font-bold">タスク情報</h3>
-        <div className="flex flex-col gap-2">
-          <div className="flex items-center">
-            <div className="min-w-[120px]">ステータス</div>
-            <div>
-              {task.statusType ? STATUS_LABEL[task.statusType] : "未設定"}
-            </div>
-          </div>
-          <div className="flex items-center">
-            <div className="min-w-[120px]">優先度</div>
-            <div>
-              {task.priorityType ? PRIORITY_LABEL[task.priorityType] : "未設定"}
-            </div>
-          </div>
-          <div className="flex items-center">
-            <div className="min-w-[120px]">作成者</div>
-            <div>{task.createdBy}</div>
-          </div>
-          <div className="flex items-center">
-            <div className="min-w-[120px]">期日</div>
-            <div>
-              {task.dueDate
-                ? new Date(task.dueDate).toLocaleDateString("ja")
-                : "未設定"}
-            </div>
-          </div>
-          <div className="flex items-center">
-            <div className="min-w-[120px]">作成日</div>
-            <div>{dayjs(task.createdAt).format("YYYY年MM月DD日 HH:mm")}</div>
-          </div>
-          <div className="flex items-center">
-            <div className="min-w-[120px]">更新日</div>
-            <div>{dayjs(task.updatedAt).format("YYYY年MM月DD日 HH:mm")}</div>
+      <div className="flex gap-4 w-full">
+        <div className="border rounded-lg p-4 flex flex-col gap-4 min-h-50 w-[70%]">
+          <div className="flex flex-col gap-2">
+            <div className="min-w-[150px] font-bold">説明</div>
+            <Markdown
+              components={markdownComponents}
+              remarkPlugins={markdownRemarkPlugins}
+            >
+              {task.description}
+            </Markdown>
           </div>
         </div>
+        <div className="border rounded-lg p-4 flex flex-col gap-2 w-[30%]">
+          <h3 className="text-md font-bold">タスク情報</h3>
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center">
+              <div className="min-w-[120px]">ステータス</div>
+              <div>
+                {task.statusType ? STATUS_LABEL[task.statusType] : "未設定"}
+              </div>
+            </div>
+            <div className="flex items-center">
+              <div className="min-w-[120px]">優先度</div>
+              <div>
+                {task.priorityType
+                  ? PRIORITY_LABEL[task.priorityType]
+                  : "未設定"}
+              </div>
+            </div>
+            <div className="flex items-center">
+              <div className="min-w-[120px]">作成者</div>
+              <div>{task.createdBy}</div>
+            </div>
+            <div className="flex items-center">
+              <div className="min-w-[120px]">期日</div>
+              <div>
+                {task.dueDate
+                  ? new Date(task.dueDate).toLocaleDateString("ja")
+                  : "未設定"}
+              </div>
+            </div>
+            <div className="flex items-center">
+              <div className="min-w-[120px]">作成日</div>
+              <div>{dayjs(task.createdAt).format("YYYY年MM月DD日 HH:mm")}</div>
+            </div>
+            <div className="flex items-center">
+              <div className="min-w-[120px]">更新日</div>
+              <div>{dayjs(task.updatedAt).format("YYYY年MM月DD日 HH:mm")}</div>
+            </div>
+          </div>
+        </div>
+        <DeleteTaskModal
+          task={task}
+          opened={isDeleteTaskModalOpen}
+          onOpenChange={setIsDeleteTaskModalOpen}
+          onDelete={() => router.push(Paths.DASH_BOARD)}
+        />
       </div>
-    </div>
+    </>
   );
 };

--- a/app/(auth)/dashboard/[id]/page.tsx
+++ b/app/(auth)/dashboard/[id]/page.tsx
@@ -1,7 +1,4 @@
-import Link from "next/link";
-import { BsPencil } from "react-icons/bs";
 import { Breadcrumb } from "@/components/Breadcrumb";
-import { Button } from "@/components/ui/button";
 import { Paths } from "@/consts/consts";
 import type { TaskDetail as TaskDetailType } from "@/types/taskTypes";
 import { TaskDetail } from "./TaskDetail";
@@ -39,15 +36,6 @@ export default function Page() {
           },
         ]}
       />
-      <div className="flex justify-between">
-        <h1 className="text-2xl font-bold">{taskDetail.name}</h1>
-        <Button asChild className="px-4 py-2 h-fit">
-          <Link href={Paths.TASK_EDIT.replace(":id", taskDetail.id.toString())}>
-            <BsPencil />
-            編集
-          </Link>
-        </Button>
-      </div>
       <TaskDetail task={dummyTaskDetail} />
     </div>
   );

--- a/components/task/modal/DeleteTaskModal.tsx
+++ b/components/task/modal/DeleteTaskModal.tsx
@@ -20,12 +20,20 @@ interface Props {
   };
   opened: boolean;
   onOpenChange: (open: boolean) => void;
+  onDelete: () => void;
 }
 
-export const DeleteTaskModal = ({ task, opened, onOpenChange }: Props) => {
+export const DeleteTaskModal = ({
+  task,
+  opened,
+  onOpenChange,
+  onDelete,
+}: Props) => {
   const handleDelete = () => {
     console.log(`taskId: ${task.id}`);
     toast.success("タスクを削除しました");
+    onDelete();
+    onOpenChange(false);
   };
 
   return (

--- a/components/task/modal/DeleteTaskModal.tsx
+++ b/components/task/modal/DeleteTaskModal.tsx
@@ -1,0 +1,76 @@
+import { FiAlertTriangle } from "react-icons/fi";
+import { TbTrash } from "react-icons/tb";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface Props {
+  task: {
+    id: number;
+    name: string;
+  };
+  opened: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const DeleteTaskModal = ({ task, opened, onOpenChange }: Props) => {
+  const handleDelete = () => {
+    console.log(`taskId: ${task.id}`);
+    toast.success("タスクを削除しました");
+  };
+
+  return (
+    <Dialog open={opened} onOpenChange={onOpenChange}>
+      <DialogPortal>
+        <DialogOverlay />
+        <DialogContent>
+          <DialogTitle hidden />
+          <DialogDescription hidden />
+          <div className="flex flex-col items-center gap-4">
+            <div className="rounded-full bg-destructive/10 text-destructive size-12 flex items-center justify-center">
+              <FiAlertTriangle className="text-2xl" />
+            </div>
+            <span className="text-lg font-bold">
+              このタスクを削除しますか？
+            </span>
+            <div className="flex flex-col items-center text-xs">
+              <span className="text-muted-foreground">
+                {`「${task.name}」を削除すると、`}
+              </span>
+              <span className="text-muted-foreground">
+                関連するサブタスクやコメントもすべて削除されます。
+              </span>
+              <span className="text-muted-foreground">
+                この操作は取り消せません。
+              </span>
+            </div>
+            <DialogFooter className="w-full gap-4">
+              <DialogClose asChild>
+                <Button className="grow" variant="outline">
+                  キャンセル
+                </Button>
+              </DialogClose>
+              <Button
+                className="grow"
+                variant="destructive"
+                onClick={handleDelete}
+              >
+                <TbTrash />
+                削除
+              </Button>
+            </DialogFooter>
+          </div>
+        </DialogContent>
+      </DialogPortal>
+    </Dialog>
+  );
+};


### PR DESCRIPTION
## 変更内容
タスク削除モーダルのUIを作成し、
タスク一覧画面、タスク詳細画面から表示できるようにしました。

## 完了条件
- タスク一覧画面の各タスクの行にタスク削除アイコンを追加する
- タスク削除アイコンを押下するとタスク削除モーダルが表示される
- タスク詳細画面にタスク削除ボタンを追加する
- タスク削除ボタンを押下するとタスク削除モーダルが表示される
- タスク削除モーダル内で削除ボタンを押下すると、成功通知が表示される

## 補足事項
### タスク一覧
<img width="1466" height="720" alt="image" src="https://github.com/user-attachments/assets/ea5f5936-e1e4-4896-9bed-f86c4ab83ac5" />

### タスク詳細
<img width="1466" height="720" alt="image" src="https://github.com/user-attachments/assets/4eff783f-3836-464e-a34b-63754a25b38b" />

### タスク削除モーダル
<img width="436" height="320" alt="image" src="https://github.com/user-attachments/assets/455d1343-1d03-4c44-bd8b-3d262f642ef4" />
