### PR TITLE
feat: マークダウンプレビュー表示を実装

### DIFF
--- a/app/(auth)/dashboard/[id]/edit/EditTaskForm.tsx
+++ b/app/(auth)/dashboard/[id]/edit/EditTaskForm.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { zodResolver } from "@hookform/resolvers/zod";
+import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Controller, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { DatePickerButton } from "@/components/DatePickerButton";
+import { MarkdownEditor } from "@/components/MarkdownEditor";
 import { Button } from "@/components/ui/button";
 import {
   Field,
@@ -20,7 +21,6 @@ import {
   NativeSelect,
   NativeSelectOption,
 } from "@/components/ui/native-select";
-import { Textarea } from "@/components/ui/textarea";
 import { Paths } from "@/consts/consts";
 import { PRIORITY_LABEL, STATUS_LABEL } from "@/consts/task";
 import { type TaskInput, taskSchema } from "@/schemas/taskSchema";
@@ -39,12 +39,12 @@ export const EditTaskForm = ({ task }: Props) => {
     handleSubmit,
     formState: { errors },
   } = useForm<TaskInput>({
-    resolver: zodResolver(taskSchema),
+    resolver: standardSchemaResolver(taskSchema),
     defaultValues: {
       name: task.name,
       description: task.description,
-      statusType: task.statusType ?? "",
-      priorityType: task.priorityType ?? "",
+      statusType: task.statusType || "",
+      priorityType: task.priorityType || "",
       dueDate: task.dueDate,
     },
   });
@@ -76,16 +76,21 @@ export const EditTaskForm = ({ task }: Props) => {
                 </FieldContent>
                 <FieldError errors={[errors.name]} />
               </Field>
-              <Field className="h-full">
+              <Field className="h-full flex flex-col">
                 <FieldLabel htmlFor="description" className="font-bold">
                   説明
                 </FieldLabel>
-                <FieldContent>
-                  <Textarea
-                    id="description"
-                    placeholder="説明を入力してください"
-                    className="field-sizing-fixed flex-1 h-full resize-none"
-                    {...register("description")}
+                <FieldContent className="flex flex-col flex-1">
+                  <Controller
+                    name="description"
+                    control={control}
+                    render={({ field }) => (
+                      <MarkdownEditor
+                        value={field.value}
+                        onChange={field.onChange}
+                        placeholder="説明を入力してください"
+                      />
+                    )}
                   />
                 </FieldContent>
               </Field>

--- a/app/(auth)/dashboard/create/CreateTaskForm.tsx
+++ b/app/(auth)/dashboard/create/CreateTaskForm.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { zodResolver } from "@hookform/resolvers/zod";
+import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Controller, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { DatePickerButton } from "@/components/DatePickerButton";
+import { MarkdownEditor } from "@/components/MarkdownEditor";
 import { Button } from "@/components/ui/button";
 import {
   Field,
@@ -20,7 +21,6 @@ import {
   NativeSelect,
   NativeSelectOption,
 } from "@/components/ui/native-select";
-import { Textarea } from "@/components/ui/textarea";
 import { Paths } from "@/consts/consts";
 import { PRIORITY_LABEL, STATUS_LABEL } from "@/consts/task";
 import { type TaskInput, taskSchema } from "@/schemas/taskSchema";
@@ -34,7 +34,7 @@ export const CreateTaskForm = () => {
     handleSubmit,
     formState: { errors },
   } = useForm<TaskInput>({
-    resolver: zodResolver(taskSchema),
+    resolver: standardSchemaResolver(taskSchema),
     defaultValues: {
       name: "",
       description: "",
@@ -71,16 +71,21 @@ export const CreateTaskForm = () => {
                 </FieldContent>
                 <FieldError errors={[errors.name]} />
               </Field>
-              <Field className="h-full">
+              <Field className="h-full flex flex-col">
                 <FieldLabel htmlFor="description" className="font-bold">
                   説明
                 </FieldLabel>
-                <FieldContent>
-                  <Textarea
-                    id="description"
-                    placeholder="説明を入力してください"
-                    className="field-sizing-fixed flex-1 h-full resize-none"
-                    {...register("description")}
+                <FieldContent className="flex flex-col flex-1">
+                  <Controller
+                    name="description"
+                    control={control}
+                    render={({ field }) => (
+                      <MarkdownEditor
+                        value={field.value}
+                        onChange={field.onChange}
+                        placeholder="説明を入力してください"
+                      />
+                    )}
                   />
                 </FieldContent>
               </Field>

--- a/components/MarkdownEditor.tsx
+++ b/components/MarkdownEditor.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import ReactMarkdown from "react-markdown";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import { markdownComponents } from "@/lib/markdownComponents";
+import { markdownRemarkPlugins } from "@/lib/markdownPlugins";
+
+interface Props {
+  value?: string;
+  onChange?: (value: string) => void;
+  placeholder?: string;
+}
+
+export const MarkdownEditor = ({
+  value = "",
+  onChange,
+  placeholder,
+}: Props) => {
+  const [tab, setTab] = useState<"edit" | "preview">("edit");
+
+  return (
+    <Tabs
+      value={tab}
+      onValueChange={(v) => setTab(v as "edit" | "preview")}
+      className="flex flex-col flex-1 h-full"
+    >
+      <TabsList variant="line" className="self-start mb-1">
+        <TabsTrigger value="edit">編集</TabsTrigger>
+        <TabsTrigger value="preview">プレビュー</TabsTrigger>
+      </TabsList>
+      <TabsContent value="edit" className="flex flex-col flex-1 mt-0">
+        <Textarea
+          value={value}
+          onChange={(e) => onChange?.(e.target.value)}
+          placeholder={placeholder}
+          className="flex-1 h-full resize-none"
+        />
+      </TabsContent>
+      <TabsContent value="preview" className="mt-0">
+        <div className="min-h-32 rounded-md border p-3">
+          {value ? (
+            <ReactMarkdown
+              components={markdownComponents}
+              remarkPlugins={markdownRemarkPlugins}
+            >
+              {value}
+            </ReactMarkdown>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              プレビューするコンテンツがありません
+            </p>
+          )}
+        </div>
+      </TabsContent>
+    </Tabs>
+  );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.4.0",
+        "@tailwindcss/typography": "^0.5.20",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -3879,6 +3880,31 @@
         "@tailwindcss/oxide": "4.2.2",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+      "integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@ts-morph/common": {
@@ -12182,8 +12208,8 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.4.0
+        version: 5.4.0(react-hook-form@7.78.0(react@19.2.4))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -365,6 +368,11 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
+
+  '@hookform/resolvers@5.4.0':
+    resolution: {integrity: sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1380,6 +1388,9 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -4443,6 +4454,11 @@ snapshots:
     dependencies:
       hono: 4.12.14
 
+  '@hookform/resolvers@5.4.0(react-hook-form@7.78.0(react@19.2.4))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.78.0(react@19.2.4)
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -5450,6 +5466,8 @@ snapshots:
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:


### PR DESCRIPTION
## 概要
タスク作成、タスク編集画面にマークダウンプレビュー機能を追加した。

## 変更内容
- `MarkdownEditor` コンポーネントを追加し、作成/編集フォームでマークダウンプレビュー表示に対応
- markdown resolver を StandardResolver に変更した

## 完了条件
- タスク作成画面でマークダウン記法がプレビュー表示されることを確認
- タスク編集画面でマークダウン記法がプレビュー表示されることを確認